### PR TITLE
Clear the Enter key in a form submission, to avoid false submission.

### DIFF
--- a/script/autocomplete.js
+++ b/script/autocomplete.js
@@ -162,7 +162,7 @@ app.directive('autocomplete', function(){
             return;
         }
 
-        if(getIndex()!==-1)
+        if(getIndex()!==-1 || keycode == key.enter)
           e.preventDefault();
       });
     },


### PR DESCRIPTION
Hello, I'm a front end developer from China, you can call me Peach.Than you for write this plug, it help me completed my project, but I find some problem, so I would like to ask your opinion. 

When I used the plug in a form, and I used the 'Enter' key to selected the items, the form will be submit, but the most user maybe just wan to selected the item instead of submit the form. So I think it should be change, what do you think?
