### PR TITLE
Hide autocomplete on blur (short timeout)

### DIFF
--- a/script/autocomplete.js
+++ b/script/autocomplete.js
@@ -120,6 +120,16 @@ app.directive('autocomplete', function(){
             e.preventDefault();
         }
       }, true);
+      
+      document.addEventListener("blur", function(e){
+        // disable suggestions on blur
+        // we do a timeout to prevent hiding it before a click event is registered
+        setTimeout(function() {
+          scope.select();
+          scope.setIndex(-1);
+          scope.$apply();
+        }, 200);
+      }, true);
 
       element.keydown(function (e){
         var keycode = e.keyCode || e.which;


### PR DESCRIPTION
Not sure if you can come up with a better solution @JustGoscha, but I chose to just put a short timeout so that when you blur away from the input the suggestion box would hide itself.

Let me know what you think.
