### PR TITLE
Don't update the suggestions if values unchanged

### DIFF
--- a/script/autocomplete.js
+++ b/script/autocomplete.js
@@ -42,7 +42,11 @@ app.directive('autocomplete', function(){
       $scope.completing = false;
 
       // starts autocompleting on typing in something
-      $scope.$watch('searchParam', function(){
+      $scope.$watch('searchParam', function(newValue, oldValue){
+        if(newValue === oldValue) {
+          return; // nothing to do here
+        }
+        
         if(watching && $scope.searchParam) {
           $scope.completing = true;
           $scope.searchFilter = $scope.searchParam;


### PR DESCRIPTION
This is to stop suggestions from opening up when `ng-model` is set by the `$scope`. When this happens, user might not have focus on the control, and suggestions open up since `searchParams` change. Since we can't count on `onfocus`, value comparison seems to be the most efficient way to go.
