### PR TITLE
Don't show suggestions on ng-model pre-population

### DIFF
--- a/script/autocomplete.js
+++ b/script/autocomplete.js
@@ -42,7 +42,11 @@ app.directive('autocomplete', function(){
       $scope.completing = false;
 
       // starts autocompleting on typing in something
-      $scope.$watch('searchParam', function(){
+      $scope.$watch('searchParam', function(newValue, oldValue){
+        if (oldValue === newValue) {
+          return;
+        }
+
         if(watching && $scope.searchParam) {
           $scope.completing = true;
           $scope.searchFilter = $scope.searchParam;


### PR DESCRIPTION
When ng-model is prepopulated by `$scope`, the suggestions open up. 

This is undesirable since a user may populate the ng-model of `autocomplete` by `$scope.foo=bar` without user intervention on an initial load. This  Since `onfocus` is sketchy here, this is the most efficient way to go.
