### PR TITLE
allow submitting forms on Enter keypress

### DIFF
--- a/script/autocomplete.js
+++ b/script/autocomplete.js
@@ -153,6 +153,9 @@ app.directive('autocomplete', function() {
 
         var l = angular.element(this).find('li').length;
 
+        // this allows submitting forms by pressing Enter in the autocompleted field
+        if(!scope.completing || l == 0) return;
+
         // implementation of the up and down movement in the list of suggestions
         switch (keycode){
           case key.up:


### PR DESCRIPTION
If an autocomplete field was in a form, it used to be impossible to submit the form's data by pressing Enter on keyboard (even after user was done with autocompleting and/or entered something new).
