### PR TITLE
Proper searchFilter update

### DIFF
--- a/script/autocomplete.js
+++ b/script/autocomplete.js
@@ -43,7 +43,7 @@ app.directive('autocomplete', function() {
           return;
         }
 
-        if(watching && $scope.searchParam) {
+        if(watching && typeof $scope.searchParam !== 'undefined' && $scope.searchParam !== null) {
           $scope.completing = true;
           $scope.searchFilter = $scope.searchParam;
           $scope.selectedIndex = -1;


### PR DESCRIPTION
Options were not updated correctly in case of erasing input value.

Example:
If you type e.g. '+' in the original demo and than hit backspace, there will still be suggestions for '+'.

// sorry for first PR (#53), which was made from master, and I canceled it
