### PR TITLE
Fix bower invalid-meta error

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "allmighty-autocomplete",
   "version": "1.0.140706",
+  "ignore": [],
   "homepage": "http://justgoscha.github.io/allmighty-autocomplete/",
   "authors": [
     "Goscha Graf <justgoscha@gmail.com>"


### PR DESCRIPTION
When installing package with bower install it shows a warning of invalid meta.
Possibly impacting in rails-assets referencing it.
