### PR TITLE
Delay on click activation

### DIFF
--- a/script/autocomplete.js
+++ b/script/autocomplete.js
@@ -118,8 +118,10 @@ app.directive('autocomplete', function() {
       if (attrs.clickActivation) {
         element[0].onclick = function(e){
           if(!scope.searchParam){
-            scope.completing = true;
-            scope.$apply();
+            setTimeout(function() {
+              scope.completing = true;
+              scope.$apply();
+            }, 200);
           }
         };
       }
@@ -146,7 +148,7 @@ app.directive('autocomplete', function() {
           scope.select();
           scope.setIndex(-1);
           scope.$apply();
-        }, 200);
+        }, 150);
       }, true);
 
       element[0].addEventListener("keydown",function (e){


### PR DESCRIPTION
I was using this directive inside of Angular Bootstrap modal window with click activation turned on. Didn't figured out why, but something was firing blur event over this directive after first focus.

So, this PR adds a little delay to click activation in order to eliminate hiding suggestions after catching immediate blur event.
