### PR TITLE
Bugfix of autocomplete suppression during initialization

### DIFF
--- a/script/autocomplete.js
+++ b/script/autocomplete.js
@@ -17,6 +17,8 @@ app.directive('autocomplete', function() {
       // the index of the suggestions that's currently selected
       $scope.selectedIndex = -1;
 
+      $scope.initLock = true;
+
       // set new index
       $scope.setIndex = function(i){
         $scope.selectedIndex = parseInt(i);
@@ -40,7 +42,7 @@ app.directive('autocomplete', function() {
       // starts autocompleting on typing in something
       $scope.$watch('searchParam', function(newValue, oldValue){
 
-        if (oldValue === newValue || !oldValue) {
+        if (oldValue === newValue || (!oldValue && $scope.initLock)) {
           return;
         }
 
@@ -94,6 +96,11 @@ app.directive('autocomplete', function() {
 
     }],
     link: function(scope, element, attrs){
+
+      setTimeout(function() {
+        scope.initLock = false;
+        scope.$apply();
+      }, 250);
 
       var attr = '';
 


### PR DESCRIPTION
If you have click activation turned on and pass a value during directive inicialization, suggestions shouldn't be displayed.

Existing solution had a bug. It didn't suppressed suggestions only after initialization, but whenever old input was evaluated to false (=empty string or first type after initialization without passing init value).
