### PR TITLE
Required attribute for input field

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can also pass a function that receives changes with the `on-type` attribute.
 
 `attr-input-id`: *(optional)* Change the id of the `input` element, see `attrs-input-class`.
 
-`autocomplete-required`: *(optional)* This attribute provides model for an ng-required attribute on the directive's input field.
+`autocomplete-required`: *(optional)* This attribute provides value for an `ng-required` attribute on the directive's `input` field.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ You can also pass a function that receives changes with the `on-type` attribute.
 
 `attr-input-id`: *(optional)* Change the id of the `input` element, see `attrs-input-class`.
 
+`autocomplete-required`: *(optional)* This attribute provides model for an ng-required attribute on the directive's input field.
+
 ## Example
 
 HTML:

--- a/script/autocomplete.js
+++ b/script/autocomplete.js
@@ -11,7 +11,8 @@ app.directive('autocomplete', function() {
       searchParam: '=ngModel',
       suggestions: '=data',
       onType: '=onType',
-      onSelect: '=onSelect'
+      onSelect: '=onSelect',
+      autocompleteRequired: '='
     },
     controller: ['$scope', function($scope){
       // the index of the suggestions that's currently selected
@@ -246,7 +247,8 @@ app.directive('autocomplete', function() {
             ng-model="searchParam"\
             placeholder="{{ attrs.placeholder }}"\
             class="{{ attrs.inputclass }}"\
-            id="{{ attrs.inputid }}"/>\
+            id="{{ attrs.inputid }}"\
+            ng-required="{{ autocompleteRequired }}" />\
           <ul ng-show="completing && suggestions.length>0">\
             <li\
               suggestion\


### PR DESCRIPTION
Hi, I needed to have a required attribute on the directive's input field. So I added an attribute and I passed the value down to a new ng-required attribute on the input field.

Seems to work correctly with and without the attribute, so it's just another option. Hope it works well for you.