### PR TITLE
Added Name attribute in Input field

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ You can also pass a function that receives changes with the `on-type` attribute.
 
 `attr-input-class`: *(optional)* Set the class of the `input` element, allowing you to style the input field directly.
 
+`attr-input-name`: *(optional)* Set the name attribute of the `input` element
+
 `attr-input-id`: *(optional)* Change the id of the `input` element, see `attrs-input-class`.
 
 `autocomplete-required`: *(optional)* This attribute provides value for an `ng-required` attribute on the directive's `input` field.

--- a/script/autocomplete.js
+++ b/script/autocomplete.js
@@ -111,7 +111,8 @@ app.directive('autocomplete', function() {
         "class": "",
         "id": "",
         "inputclass": "",
-        "inputid": ""
+        "inputid": "",
+        "inputname": "",
       };
 
       for (var a in attrs) {
@@ -248,6 +249,7 @@ app.directive('autocomplete', function() {
             placeholder="{{ attrs.placeholder }}"\
             class="{{ attrs.inputclass }}"\
             id="{{ attrs.inputid }}"\
+            name="{{ attrs.inputname }}"\
             ng-required="{{ autocompleteRequired }}" />\
           <ul ng-show="completing && (suggestions | filter:searchFilter).length > 0">\
             <li\


### PR DESCRIPTION
This adds an attribute ``attr-input-name`` which allows the user to add name attribute to the input field inside the autocomplete tag 