### PR TITLE
disable browser autocomplete

### DIFF
--- a/script/autocomplete.js
+++ b/script/autocomplete.js
@@ -248,6 +248,7 @@ app.directive('autocomplete', function() {
             placeholder="{{ attrs.placeholder }}"\
             class="{{ attrs.inputclass }}"\
             id="{{ attrs.inputid }}"\
+            autocomplete="off"\
             ng-required="{{ autocompleteRequired }}" />\
           <ul ng-show="completing && (suggestions | filter:searchFilter).length > 0">\
             <li\


### PR DESCRIPTION
It got in the way of my "city" field. The browser would pipe up and start offering auto-fills that were not in my completions list.