### PR TITLE
inputclass not being respected

### DIFF
--- a/script/autocomplete.js
+++ b/script/autocomplete.js
@@ -118,7 +118,7 @@ app.directive('autocomplete', function() {
         attr = a.replace('attr', '').toLowerCase();
         // add attribute overriding defaults
         // and preventing duplication
-        if (a.indexOf('attr') === 0) {
+        if (a.indexOf('attr') === -1) {
           scope.attrs[attr] = attrs[a];
         }
       }


### PR DESCRIPTION
the check for whether the attribute name contains attr will always return -1 because line 118 removes them.
By changing line 121, at least the attributes are respected.