### PR TITLE
Disable filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ You can also pass a function that receives changes with the `on-type` attribute.
 
 `autocomplete-required`: *(optional)* This attribute provides value for an `ng-required` attribute on the directive's `input` field.
 
+`disable-filter`: *(optional)* When `true` it will not filter the results from the list of suggestions, showing all the elements in the list. Default `false`.
+
 ## Example
 
 HTML:

--- a/script/autocomplete.js
+++ b/script/autocomplete.js
@@ -12,7 +12,8 @@ app.directive('autocomplete', function() {
       suggestions: '=data',
       onType: '=onType',
       onSelect: '=onSelect',
-      autocompleteRequired: '='
+      autocompleteRequired: '=',
+      disableFilter: '=disableFilter'
     },
     controller: ['$scope', function($scope){
       // the index of the suggestions that's currently selected
@@ -49,7 +50,7 @@ app.directive('autocomplete', function() {
 
         if(watching && typeof $scope.searchParam !== 'undefined' && $scope.searchParam !== null) {
           $scope.completing = true;
-          $scope.searchFilter = $scope.searchParam;
+          $scope.searchFilter = $scope.disableFilter ? '' : $scope.searchParam;
           $scope.selectedIndex = -1;
         }
 


### PR DESCRIPTION
Add the attribute `disable-filter` to disable the filter functionality so that it will show the complete list of suggestions.
I needed this feature because if you fetch the list from an external resource, you can already filter the results. Sometimes the suggested results don't have the exact name as the intended search. For example if you search airports, you can write the IATA code, include the city of the airport in the suggested results and it will still keep the suggested city in the list.