### PR TITLE
Run onSelect function if user does not make a selection, but hits "enter" key

### DIFF
--- a/script/autocomplete.js
+++ b/script/autocomplete.js
@@ -221,6 +221,9 @@ app.directive('autocomplete', function() {
             } else {
               if(keycode == key.enter) {
                 scope.select();
+                if(scope.onSelect) {
+                  scope.onSelect(scope.searchParam);
+                }
               }
             }
             scope.setIndex(-1);


### PR DESCRIPTION
I wanted to run the onSelect function if the user decides to type out the entire string and hit 'enter' instead of typing part of a string and making a selection from the autocomplete list.