### PR TITLE
added angular dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,5 +12,8 @@
     "angularjs"
   ],
   "license": "MIT",
-  "main": ["./script/autocomplete.js", "./style/autocomplete.css"]
+  "main": ["./script/autocomplete.js", "./style/autocomplete.css"],
+  "dependencies": {
+    "angular": ">1.0.0"
+  }
 }


### PR DESCRIPTION
When using bower for allmighty-autocomplete and angular alphabetical ordering places allmighty-autocomplete before angular. This causes an error because autocomplete needs angular. This solves the problem. @mshenfield mentioned the problem in issue #100 