### PR TITLE
escape special characters when matching highlight string

### DIFF
--- a/script/autocomplete.js
+++ b/script/autocomplete.js
@@ -267,6 +267,7 @@ app.filter('highlight', ['$sce', function ($sce) {
   return function (input, searchParam) {
     if (typeof input === 'function') return '';
     if (searchParam) {
+      searchParam = escapeSpecialCharacters(searchParam);
       var words = '(' +
             searchParam.split(/\ /).join(' |') + '|' +
             searchParam.split(/\ /).join('|') +
@@ -296,3 +297,8 @@ app.directive('suggestion', function(){
     }
   };
 });
+
+// escape characters that may be interpreted as regex expressions
+function escapeSpecialCharacters(string) {
+    return string.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+}


### PR DESCRIPTION
Entering a "(" or "[" would throw a javascript error. 
This fix allows matching strings with characters that would otherwise be parsed as regular expression matchers.