### PR TITLE
Removed console.log

### DIFF
--- a/script/autocomplete.js
+++ b/script/autocomplete.js
@@ -98,7 +98,7 @@ app.directive('autocomplete', function() {
 
     }],
     link: function(scope, element, attrs){
-        console.log(scope.noAutoSort)
+        //console.log(scope.noAutoSort)
 
       setTimeout(function() {
         scope.initLock = false;


### PR DESCRIPTION
I think console.log should not be used like this without checking because it will throw error on IE. I have commented it out.