### PR TITLE
Ability to override directive template

### DIFF
--- a/script/autocomplete.js
+++ b/script/autocomplete.js
@@ -2,311 +2,321 @@
 
 var app = angular.module('autocomplete', []);
 
-app.directive('autocomplete', function() {
-  var index = -1;
+app.directive('autocomplete', ['$templateCache', function ($templateCache) {
+    var index = -1;
 
-  return {
-    restrict: 'E',
-    scope: {
-      searchParam: '=ngModel',
-      suggestions: '=data',
-      onType: '=onType',
-      onSelect: '=onSelect',
-      autocompleteRequired: '=',
-      noAutoSort: '=noAutoSort'
-    },
-    controller: ['$scope', function($scope){
-      // the index of the suggestions that's currently selected
-      $scope.selectedIndex = -1;
+    var TEMPLATE_URL = 'ac_template.html';
 
-      $scope.initLock = true;
+    $templateCache.put(TEMPLATE_URL,
+        '\
+            <div class="autocomplete {{ attrs.class }}" id="{{ attrs.id }}">\
+              <input\
+                type="text"\
+                ng-model="searchParam"\
+                placeholder="{{ attrs.placeholder }}"\
+                class="{{ attrs.inputclass }}"\
+                tabindex="{{ attrs.tabindex }}"\
+                id="{{ attrs.inputid }}"\
+                name="{{ attrs.name }}"\
+                ng-required="{{ autocompleteRequired }}" />\
+              <ul ng-if="!noAutoSort" ng-show="completing && (suggestions | filter:searchFilter).length > 0">\
+                <li\
+                  suggestion\
+                  ng-repeat="suggestion in suggestions | filter:searchFilter | orderBy:\'toString()\' track by $index"\
+                  index="{{ $index }}"\
+                  val="{{ suggestion }}"\
+                  ng-class="{ active: ($index === selectedIndex) }"\
+                  ng-click="select(suggestion)"\
+                  ng-bind-html="suggestion | highlight:searchParam"></li>\
+              </ul>\
+              <ul ng-if="noAutoSort" ng-show="completing && (suggestions | filter:searchFilter).length > 0">\
+                <li\
+                  suggestion\
+                  ng-repeat="suggestion in suggestions | filter:searchFilter track by $index"\
+                  index="{{ $index }}"\
+                  val="{{ suggestion }}"\
+                  ng-class="{ active: ($index === selectedIndex) }"\
+                  ng-click="select(suggestion)"\
+                  ng-bind-html="suggestion | highlight:searchParam"></li>\
+              </ul>\
+            </div>'
+    );
 
-      // set new index
-      $scope.setIndex = function(i){
-        $scope.selectedIndex = parseInt(i);
-      };
+    return {
+        restrict: 'E',
+        scope: {
+            searchParam: '=ngModel',
+            suggestions: '=data',
+            onType: '=onType',
+            onSelect: '=onSelect',
+            autocompleteRequired: '=',
+            noAutoSort: '=noAutoSort'
+        },
+        controller: ['$scope', function ($scope) {
+            // the index of the suggestions that's currently selected
+            $scope.selectedIndex = -1;
 
-      this.setIndex = function(i){
-        $scope.setIndex(i);
-        $scope.$apply();
-      };
+            $scope.initLock = true;
 
-      $scope.getIndex = function(i){
-        return $scope.selectedIndex;
-      };
+            // set new index
+            $scope.setIndex = function (i) {
+                $scope.selectedIndex = parseInt(i);
+            };
 
-      // watches if the parameter filter should be changed
-      var watching = true;
+            this.setIndex = function (i) {
+                $scope.setIndex(i);
+                $scope.$apply();
+            };
 
-      // autocompleting drop down on/off
-      $scope.completing = false;
+            $scope.getIndex = function (i) {
+                return $scope.selectedIndex;
+            };
 
-      // starts autocompleting on typing in something
-      $scope.$watch('searchParam', function(newValue, oldValue){
+            // watches if the parameter filter should be changed
+            var watching = true;
 
-        if (oldValue === newValue || (!oldValue && $scope.initLock)) {
-          return;
-        }
+            // autocompleting drop down on/off
+            $scope.completing = false;
 
-        if(watching && typeof $scope.searchParam !== 'undefined' && $scope.searchParam !== null) {
-          $scope.completing = true;
-          $scope.searchFilter = $scope.searchParam;
-          $scope.selectedIndex = -1;
-        }
+            // starts autocompleting on typing in something
+            $scope.$watch('searchParam', function (newValue, oldValue) {
 
-        // function thats passed to on-type attribute gets executed
-        if($scope.onType)
-          $scope.onType($scope.searchParam);
-      });
+                if (oldValue === newValue || (!oldValue && $scope.initLock)) {
+                    return;
+                }
 
-      // for hovering over suggestions
-      this.preSelect = function(suggestion){
+                if (watching && typeof $scope.searchParam !== 'undefined' && $scope.searchParam !== null) {
+                    $scope.completing = true;
+                    $scope.searchFilter = $scope.searchParam;
+                    $scope.selectedIndex = -1;
+                }
 
-        watching = false;
+                // function thats passed to on-type attribute gets executed
+                if ($scope.onType)
+                    $scope.onType($scope.searchParam);
+            });
 
-        // this line determines if it is shown
-        // in the input field before it's selected:
-        //$scope.searchParam = suggestion;
+            // for hovering over suggestions
+            this.preSelect = function (suggestion) {
 
-        $scope.$apply();
-        watching = true;
+                watching = false;
 
-      };
+                // this line determines if it is shown
+                // in the input field before it's selected:
+                //$scope.searchParam = suggestion;
 
-      $scope.preSelect = this.preSelect;
+                $scope.$apply();
+                watching = true;
 
-      this.preSelectOff = function(){
-        watching = true;
-      };
+            };
 
-      $scope.preSelectOff = this.preSelectOff;
+            $scope.preSelect = this.preSelect;
 
-      // selecting a suggestion with RIGHT ARROW or ENTER
-      $scope.select = function(suggestion){
-        if(suggestion){
-          $scope.searchParam = suggestion;
-          $scope.searchFilter = suggestion;
-          if($scope.onSelect)
-            $scope.onSelect(suggestion);
-        }
-        watching = false;
-        $scope.completing = false;
-        setTimeout(function(){watching = true;},1000);
-        $scope.setIndex(-1);
-      };
+            this.preSelectOff = function () {
+                watching = true;
+            };
+
+            $scope.preSelectOff = this.preSelectOff;
+
+            // selecting a suggestion with RIGHT ARROW or ENTER
+            $scope.select = function (suggestion) {
+                if (suggestion) {
+                    $scope.searchParam = suggestion;
+                    $scope.searchFilter = suggestion;
+                    if ($scope.onSelect)
+                        $scope.onSelect(suggestion);
+                }
+                watching = false;
+                $scope.completing = false;
+                setTimeout(function () {
+                    watching = true;
+                }, 1000);
+                $scope.setIndex(-1);
+            };
 
 
-    }],
-    link: function(scope, element, attrs){
-        console.log(scope.noAutoSort)
+        }],
+        link: function (scope, element, attrs) {
+            console.log(scope.noAutoSort)
 
-      setTimeout(function() {
-        scope.initLock = false;
-        scope.$apply();
-      }, 250);
+            setTimeout(function () {
+                scope.initLock = false;
+                scope.$apply();
+            }, 250);
 
-      var attr = '';
+            var attr = '';
 
-      // Default atts
-      scope.attrs = {
-        "placeholder": "start typing...",
-        "class": "",
-        "id": "",
-        "inputclass": "",
-        "inputid": ""
-      };
+            // Default atts
+            scope.attrs = {
+                "placeholder": "start typing...",
+                "class": "",
+                "id": "",
+                "inputclass": "",
+                "inputid": ""
+            };
 
-      for (var a in attrs) {
-        attr = a.replace('attr', '').toLowerCase();
-        // add attribute overriding defaults
-        // and preventing duplication
-        if (a.indexOf('attr') === 0) {
-          scope.attrs[attr] = attrs[a];
-        }
-      }
-
-      if (attrs.clickActivation) {
-        element[0].onclick = function(e){
-          if(!scope.searchParam){
-            setTimeout(function() {
-              scope.completing = true;
-              scope.$apply();
-            }, 200);
-          }
-        };
-      }
-
-      var key = {left: 37, up: 38, right: 39, down: 40 , enter: 13, esc: 27, tab: 9};
-
-      document.addEventListener("keydown", function(e){
-        var keycode = e.keyCode || e.which;
-
-        switch (keycode){
-          case key.esc:
-            // disable suggestions on escape
-            scope.select();
-            scope.setIndex(-1);
-            scope.$apply();
-            e.preventDefault();
-        }
-      }, true);
-
-      document.addEventListener("blur", function(e){
-        // disable suggestions on blur
-        // we do a timeout to prevent hiding it before a click event is registered
-        setTimeout(function() {
-          scope.select();
-          scope.setIndex(-1);
-          scope.$apply();
-        }, 150);
-      }, true);
-
-      element[0].addEventListener("keydown",function (e){
-        var keycode = e.keyCode || e.which;
-
-        var l = angular.element(this).find('li').length;
-
-        // this allows submitting forms by pressing Enter in the autocompleted field
-        if(!scope.completing || l == 0) return;
-
-        // implementation of the up and down movement in the list of suggestions
-        switch (keycode){
-          case key.up:
-
-            index = scope.getIndex()-1;
-            if(index<-1){
-              index = l-1;
-            } else if (index >= l ){
-              index = -1;
-              scope.setIndex(index);
-              scope.preSelectOff();
-              break;
+            for (var a in attrs) {
+                attr = a.replace('attr', '').toLowerCase();
+                // add attribute overriding defaults
+                // and preventing duplication
+                if (a.indexOf('attr') === 0) {
+                    scope.attrs[attr] = attrs[a];
+                }
             }
-            scope.setIndex(index);
 
-            if(index!==-1)
-              scope.preSelect(angular.element(angular.element(this).find('li')[index]).text());
-
-            scope.$apply();
-
-            break;
-          case key.down:
-            index = scope.getIndex()+1;
-            if(index<-1){
-              index = l-1;
-            } else if (index >= l ){
-              index = -1;
-              scope.setIndex(index);
-              scope.preSelectOff();
-              scope.$apply();
-              break;
+            if (attrs.clickActivation) {
+                element[0].onclick = function (e) {
+                    if (!scope.searchParam) {
+                        setTimeout(function () {
+                            scope.completing = true;
+                            scope.$apply();
+                        }, 200);
+                    }
+                };
             }
-            scope.setIndex(index);
 
-            if(index!==-1)
-              scope.preSelect(angular.element(angular.element(this).find('li')[index]).text());
+            var key = {left: 37, up: 38, right: 39, down: 40, enter: 13, esc: 27, tab: 9};
 
-            break;
-          case key.left:
-            break;
-          case key.right:
-          case key.enter:
-          case key.tab:
+            document.addEventListener("keydown", function (e) {
+                var keycode = e.keyCode || e.which;
 
-            index = scope.getIndex();
-            // scope.preSelectOff();
-            if(index !== -1) {
-              scope.select(angular.element(angular.element(this).find('li')[index]).text());
-              if(keycode == key.enter) {
-                e.preventDefault();
-              }
-            } else {
-              if(keycode == key.enter) {
-                scope.select();
-              }
-            }
-            scope.setIndex(-1);
-            scope.$apply();
+                switch (keycode) {
+                    case key.esc:
+                        // disable suggestions on escape
+                        scope.select();
+                        scope.setIndex(-1);
+                        scope.$apply();
+                        e.preventDefault();
+                }
+            }, true);
 
-            break;
-          case key.esc:
-            // disable suggestions on escape
-            scope.select();
-            scope.setIndex(-1);
-            scope.$apply();
-            e.preventDefault();
-            break;
-          default:
-            return;
+            document.addEventListener("blur", function (e) {
+                // disable suggestions on blur
+                // we do a timeout to prevent hiding it before a click event is registered
+                setTimeout(function () {
+                    scope.select();
+                    scope.setIndex(-1);
+                    scope.$apply();
+                }, 150);
+            }, true);
+
+            element[0].addEventListener("keydown", function (e) {
+                var keycode = e.keyCode || e.which;
+
+                var l = angular.element(this).find('li').length;
+
+                // this allows submitting forms by pressing Enter in the autocompleted field
+                if (!scope.completing || l == 0) return;
+
+                // implementation of the up and down movement in the list of suggestions
+                switch (keycode) {
+                    case key.up:
+
+                        index = scope.getIndex() - 1;
+                        if (index < -1) {
+                            index = l - 1;
+                        } else if (index >= l) {
+                            index = -1;
+                            scope.setIndex(index);
+                            scope.preSelectOff();
+                            break;
+                        }
+                        scope.setIndex(index);
+
+                        if (index !== -1)
+                            scope.preSelect(angular.element(angular.element(this).find('li')[index]).text());
+
+                        scope.$apply();
+
+                        break;
+                    case key.down:
+                        index = scope.getIndex() + 1;
+                        if (index < -1) {
+                            index = l - 1;
+                        } else if (index >= l) {
+                            index = -1;
+                            scope.setIndex(index);
+                            scope.preSelectOff();
+                            scope.$apply();
+                            break;
+                        }
+                        scope.setIndex(index);
+
+                        if (index !== -1)
+                            scope.preSelect(angular.element(angular.element(this).find('li')[index]).text());
+
+                        break;
+                    case key.left:
+                        break;
+                    case key.right:
+                    case key.enter:
+                    case key.tab:
+
+                        index = scope.getIndex();
+                        // scope.preSelectOff();
+                        if (index !== -1) {
+                            scope.select(angular.element(angular.element(this).find('li')[index]).text());
+                            if (keycode == key.enter) {
+                                e.preventDefault();
+                            }
+                        } else {
+                            if (keycode == key.enter) {
+                                scope.select();
+                            }
+                        }
+                        scope.setIndex(-1);
+                        scope.$apply();
+
+                        break;
+                    case key.esc:
+                        // disable suggestions on escape
+                        scope.select();
+                        scope.setIndex(-1);
+                        scope.$apply();
+                        e.preventDefault();
+                        break;
+                    default:
+                        return;
+                }
+
+            });
+        },
+        templateUrl: function (elem, attrs) {
+            return attrs.templateUrl || TEMPLATE_URL;
         }
-
-      });
-    },
-    template: '\
-        <div class="autocomplete {{ attrs.class }}" id="{{ attrs.id }}">\
-          <input\
-            type="text"\
-            ng-model="searchParam"\
-            placeholder="{{ attrs.placeholder }}"\
-            class="{{ attrs.inputclass }}"\
-            tabindex="{{ attrs.tabindex }}"\
-            id="{{ attrs.inputid }}"\
-            name="{{ attrs.name }}"\
-            ng-required="{{ autocompleteRequired }}" />\
-          <ul ng-if="!noAutoSort" ng-show="completing && (suggestions | filter:searchFilter).length > 0">\
-            <li\
-              suggestion\
-              ng-repeat="suggestion in suggestions | filter:searchFilter | orderBy:\'toString()\' track by $index"\
-              index="{{ $index }}"\
-              val="{{ suggestion }}"\
-              ng-class="{ active: ($index === selectedIndex) }"\
-              ng-click="select(suggestion)"\
-              ng-bind-html="suggestion | highlight:searchParam"></li>\
-          </ul>\
-          <ul ng-if="noAutoSort" ng-show="completing && (suggestions | filter:searchFilter).length > 0">\
-            <li\
-              suggestion\
-              ng-repeat="suggestion in suggestions | filter:searchFilter track by $index"\
-              index="{{ $index }}"\
-              val="{{ suggestion }}"\
-              ng-class="{ active: ($index === selectedIndex) }"\
-              ng-click="select(suggestion)"\
-              ng-bind-html="suggestion | highlight:searchParam"></li>\
-          </ul>\
-        </div>'
-  };
-});
-
-app.filter('highlight', ['$sce', function ($sce) {
-  return function (input, searchParam) {
-    if (typeof input === 'function') return '';
-    if (searchParam) {
-      var words = '(' +
-            searchParam.split(/\ /).join(' |') + '|' +
-            searchParam.split(/\ /).join('|') +
-          ')',
-          exp = new RegExp(words, 'gi');
-      if (words.length) {
-        input = input.replace(exp, "<span class=\"highlight\">$1</span>");
-      }
-    }
-    return $sce.trustAsHtml(input);
-  };
+    };
 }]);
 
-app.directive('suggestion', function(){
-  return {
-    restrict: 'A',
-    require: '^autocomplete', // ^look for controller on parents element
-    link: function(scope, element, attrs, autoCtrl){
-      element.bind('mouseenter', function() {
-        autoCtrl.preSelect(attrs.val);
-        autoCtrl.setIndex(attrs.index);
-      });
+app.filter('highlight', ['$sce', function ($sce) {
+    return function (input, searchParam) {
+        if (typeof input === 'function') return '';
+        if (searchParam) {
+            var words = '(' +
+                    searchParam.split(/\ /).join(' |') + '|' +
+                    searchParam.split(/\ /).join('|') +
+                    ')',
+                exp = new RegExp(words, 'gi');
+            if (words.length) {
+                input = input.replace(exp, "<span class=\"highlight\">$1</span>");
+            }
+        }
+        return $sce.trustAsHtml(input);
+    };
+}]);
 
-      element.bind('mouseleave', function() {
-        autoCtrl.preSelectOff();
-      });
-    }
-  };
+app.directive('suggestion', function () {
+    return {
+        restrict: 'A',
+        require: '^autocomplete', // ^look for controller on parents element
+        link: function (scope, element, attrs, autoCtrl) {
+            element.bind('mouseenter', function () {
+                autoCtrl.preSelect(attrs.val);
+                autoCtrl.setIndex(attrs.index);
+            });
+
+            element.bind('mouseleave', function () {
+                autoCtrl.preSelectOff();
+            });
+        }
+    };
 });


### PR DESCRIPTION
Allow template to be overridden so that custom markup and functionality can be used.

```html
<script type="text/ng-template" id="/my-custom-template.html"> { custom markup here }</script>
<autocomplete
    (..)
    template-url="/my-custom-template.html"
    (..)>
</autocomplete>
```

or

```html
<autocomplete
    (..)
    template-url="/path/to/my-custom-template.html"
    (..)>
</autocomplete>
```